### PR TITLE
Fix aside element for better scrolling on medium screens

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -224,3 +224,10 @@ export default {
   margin-right: 0;
 }
 </style>
+
+<style global>
+  aside{
+    position: fixed !important;
+    height: 100% !important;
+  }
+</style>


### PR DESCRIPTION
Added CSS position and height to aside element to improved usability and accessibility while scrolling, specifically when the screen width is 501-1023 dimension.

<details>
<summary>Before</summary>

https://user-images.githubusercontent.com/91131474/234581978-27712ffe-9fdc-42e3-8821-c9b4045bb1d5.mp4

</details>

<details>
<summary>After</summary>

https://user-images.githubusercontent.com/91131474/234582045-cd89b03a-c34e-4916-b3d2-da71b8d9e37f.mp4

</details>