### PR TITLE
refactor: update discord link

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -77,7 +77,7 @@ q-layout(
     q-toolbar.q-gutter-sm.q-my-lg.soc-med-toolbar
       q-btn(
         label="Discord"
-        href="https://discord.com/servers/open-source-software-ph-905496362982981723"
+        href="https://discord.gg/DvtqKrWb86"
         target="_blank"
         icon="fa-brands fa-discord"
         outline

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -12,7 +12,7 @@ generic-panel(
         size="lg"
         color="primary"
         icon="discord"
-        href="https://discord.com/servers/open-source-software-ph-905496362982981723"
+        href="https://discord.gg/DvtqKrWb86"
         target="_blank"
         no-caps
         unelevated
@@ -167,7 +167,7 @@ generic-panel(
         size="lg"
         color="primary"
         icon="discord"
-        href="https://discord.com/servers/open-source-software-ph-905496362982981723"
+        href="https://discord.gg/DvtqKrWb86"
         target="_blank"
         no-caps
         unelevated


### PR DESCRIPTION
This is temporary, the previous discord link is not active anymore due to removal of OSSPH in Discord discovery page. This should be returned later.