### PR TITLE
refactor: move past volunteer to list

### DIFF
--- a/src/assets/fixtures/team.json
+++ b/src/assets/fixtures/team.json
@@ -26,7 +26,7 @@
     "name": "Waren",
     "role": "Co-Founder",
     "photo": "waren.png",
-    "active": true,
+    "active": false,
     "socials": [
       {
         "name": "GitHub",


### PR DESCRIPTION
## Summary
Moved Waren's profile from the current volunteers list to the past volunteers section as per issue [#63](https://github.com/OSSPhilippines/ossph.org/issues/63).

## Changes Made
Updated the team page to reflect Waren's status change.
Moved Waren's entry to the Past Volunteers section.

## Issue Reference
Closes #63

## Testing Steps
Go to the Team page (/team).
Verify that Waren's profile is now listed under Past Volunteers instead of the active volunteers.